### PR TITLE
Add Asmlings, a rustlings-style exercises for learning x86-64 assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Contents
 
 - [Languages](#languages)
+  - [Assembly](#assembly)
   - [Clojure](#clojure)
   - [Elm](#elm)
   - [Go](#go)
@@ -26,6 +27,10 @@
 - [Contribute](#contribute)
 
 ## Languages
+
+### Assembly
+
+- [Asmlings: Learn x86-64 assembly by fixing small programs](https://github.com/KazeTachinuu/asmlings)
 
 ### Clojure
 


### PR DESCRIPTION
## Summary
- Adds [Asmlings](https://github.com/KazeTachinuu/asmlings), a rustlings-style project for learning x86-64 assembly by fixing small programs
- Creates a new Assembly section in the Languages category

## Checklist
- [x] Example-based learning resource
- [x] Technically oriented
- [x] Free and open source (MIT license)
- [x] Properly categorized and alphabetically ordered